### PR TITLE
Improve social share images and X card metadata

### DIFF
--- a/layouts/partials/templates/twitter_cards.html
+++ b/layouts/partials/templates/twitter_cards.html
@@ -2,6 +2,7 @@
 {{- if $socialImage -}}
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="{{ if hugo.IsServer }}{{ $socialImage }}{{ else }}{{ $socialImage | absURL }}{{ end }}">
+<meta name="twitter:image:alt" content="{{ .Title }}">
 {{- else if .Params.cover.image -}}
 <meta name="twitter:card" content="summary_large_image">
 {{- if (ne $.Params.cover.relative true) }}
@@ -9,11 +10,13 @@
 {{- else }}
 <meta name="twitter:image" content="{{ (path.Join .RelPermalink .Params.cover.image ) | absURL }}">
 {{- end}}
+<meta name="twitter:image:alt" content="{{ .Title }}">
 {{- else }}
 {{- $images := partial "templates/_funcs/get-page-images" . -}}
 {{- with index $images 0 -}}
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:image" content="{{ .Permalink }}">
+<meta name="twitter:image:alt" content="{{ $.Title }}">
 {{- else -}}
 <meta name="twitter:card" content="summary">
 {{- end -}}
@@ -25,11 +28,23 @@
 {{- with site.Params.social }}
   {{- if reflect.IsMap . }}
     {{- with .twitter }}
-      {{- $content := . }}
-      {{- if not (strings.HasPrefix . "@") }}
-        {{- $content = printf "@%v" . }}
-      {{- end }}
-      <meta name="twitter:site" content="{{ $content }}">
+      {{- $twitterSite = . }}
     {{- end }}
   {{- end }}
+{{- end }}
+{{- if not $twitterSite }}
+  {{- range site.Params.socialIcons }}
+    {{- if and (not $twitterSite) (or (eq .name "twitter") (eq .name "x")) }}
+      {{- $twitterSite = replaceRE `^https?://(www\\.)?(x|twitter)\\.com/` "" .url -}}
+      {{- $twitterSite = replaceRE `/.*$` "" $twitterSite -}}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- with $twitterSite }}
+  {{- $content := . }}
+  {{- if not (strings.HasPrefix $content "@") }}
+    {{- $content = printf "@%v" $content }}
+  {{- end }}
+  <meta name="twitter:site" content="{{ $content }}">
+  <meta name="twitter:creator" content="{{ $content }}">
 {{- end }}


### PR DESCRIPTION
## Summary
- generate per-post social share images with the article title overlaid
- use a Japanese-capable font and tune title wrapping/sizing for long titles
- add X card metadata fallback for x.com profiles, creator attribution, and image alt text

## Testing
- hugo
