### PR TITLE
fix: X.com ソーシャル画像が表示されないバグを修正 (twitter:site が @https: になる)

### DIFF
--- a/layouts/partials/templates/twitter_cards.html
+++ b/layouts/partials/templates/twitter_cards.html
@@ -35,8 +35,8 @@
 {{- if not $twitterSite }}
   {{- range site.Params.socialIcons }}
     {{- if and (not $twitterSite) (or (eq .name "twitter") (eq .name "x")) }}
-      {{- $twitterSite = replaceRE `^https?://(www\\.)?(x|twitter)\\.com/` "" .url -}}
-      {{- $twitterSite = replaceRE `/.*$` "" $twitterSite -}}
+      {{- $twitterSite = replaceRE `^https?://(www\.)?(x|twitter)\.com/@?` "" .url -}}
+      {{- $twitterSite = replaceRE `[/?#].*$` "" $twitterSite -}}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## 問題

X.com に記事をシェアした際、ソーシャルカード画像が正しく表示されない。

原因を調査したところ、生成される HTML に以下のような不正な値が含まれていた：

```html
<meta name="twitter:site" content="@https:">
<meta name="twitter:creator" content="@https:">
```

`@jedipunkz` が期待値だが `@https:` になっており、X.com のカードバリデーターが無効な username と判断してカード全体を無効扱いにしていた。

## 原因

`layouts/partials/templates/twitter_cards.html` の正規表現バグ。

Hugo テンプレートの raw string (バッククォート) 内では `\\` はバックスラッシュそのものとして渡されるため、regex エンジンは `\\.` を「バックスラッシュ + 任意文字」と解釈する。結果として `.com` にマッチせず、URL 全体が残ったまま `/.*$` で除去すると `https:` だけ残り `@https:` が生成されていた。

```
# 実行前
url = "https://x.com/jedipunkz"

# Step1 (バグあり): `\\.` が `.` にマッチしないためURL全体が残る
replaceRE `^https?://(www\\.)?(x|twitter)\\.com/` "" url
→ "https://x.com/jedipunkz"  ← マッチしない！

# Step2: / 以降を除去
replaceRE `/.*$` "" "https://x.com/jedipunkz"
→ "https:"  ← バグ！

# 最終出力
@https:
```

## 修正

`\\.` → `\.` に修正（Hugo raw string 内では単一バックスラッシュで literal dot にマッチ）。

```diff
- {{- $twitterSite = replaceRE `^https?://(www\\.)?(x|twitter)\\.com/` "" .url -}}
- {{- $twitterSite = replaceRE `/.*$` "" $twitterSite -}}
+ {{- $twitterSite = replaceRE `^https?://(www\.)?(x|twitter)\.com/@?` "" .url -}}
+ {{- $twitterSite = replaceRE `[/?#].*$` "" $twitterSite -}}
```

修正後の期待動作：
```
url = "https://x.com/jedipunkz"
→ Step1: "jedipunkz"
→ Step2: "jedipunkz"
→ 最終出力: @jedipunkz  ✓
```

## 確認方法

PR プレビュー (`https://jedipunkz.rocks/preview/post/gcp-cloudrun-terraform/`) の HTML を確認：

```html
<meta name="twitter:site" content="@jedipunkz">
<meta name="twitter:creator" content="@jedipunkz">
```

https://claude.ai/code/session_01449fAtFrF44W5186grwycj

---
_Generated by [Claude Code](https://claude.ai/code/session_01449fAtFrF44W5186grwycj)_