### PR TITLE
style: modernize CSS with fluid typography

### DIFF
--- a/assets/css/core/theme-vars.css
+++ b/assets/css/core/theme-vars.css
@@ -16,7 +16,15 @@
     --content: rgb(31, 41, 55);
     --hljs-bg: rgb(31, 41, 55);
     --code-bg: rgb(243, 244, 246);
+    --code-color: rgb(124, 58, 237);
     --border: rgb(229, 231, 235);
+
+    /* Fluid typography (viewport-based, no breakpoint jumps) */
+    --font-size-base: clamp(1rem, 0.94rem + 0.3vw, 1.125rem);
+    --font-size-h1: clamp(1.55rem, 1.3rem + 1.25vw, 2.1rem);
+    --font-size-h2: clamp(1.35rem, 1.18rem + 0.85vw, 1.7rem);
+    --font-size-h3: clamp(1.2rem, 1.08rem + 0.6vw, 1.45rem);
+    --font-size-h4: clamp(1.05rem, 1rem + 0.25vw, 1.2rem);
 
     /* Accent colors */
     --accent: rgb(67, 56, 202);
@@ -40,6 +48,7 @@
     --content: rgb(229, 231, 235);
     --hljs-bg: rgb(18, 19, 28);
     --code-bg: rgb(18, 19, 28);
+    --code-color: rgb(187, 154, 247);
     --border: rgb(52, 54, 66);
 
     /* Accent colors for dark mode */

--- a/assets/css/extended/main.css
+++ b/assets/css/extended/main.css
@@ -17,10 +17,10 @@ body {
   margin: 0;
   padding: 0;
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Roboto", "Segoe UI",  Helvetica, Arial, sans-serif;
-  font-size: 1.125rem;
+  font-size: var(--font-size-base);
   font-weight: 400;
   font-feature-settings: "liga", "tnum", "case", "calt", "zero", "ss01", "locl";
-  line-height: 1.9;
+  line-height: 1.8;
   letter-spacing: -0.011em;
   /* background-color: var(--background); */
   /* color: var(--color); */
@@ -31,9 +31,13 @@ body {
   -webkit-text-size-adjust: 100%;
 
   @media (--phone) {
-    font-size: 1rem;
     line-height: 1.75;
   }
+}
+
+/* Better paragraph wrapping (avoids orphans/awkward breaks) */
+p {
+  text-wrap: pretty;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -43,10 +47,11 @@ h1, h2, h3, h4, h5, h6 {
   color: var(--primary);
   margin-top: 2rem;
   margin-bottom: 1rem;
+  text-wrap: balance;
 }
 
 h1 {
-  font-size: 1.7em;
+  font-size: var(--font-size-h1);
   font-weight: 800;
   letter-spacing: -0.035em;
   margin-top: 0;
@@ -54,36 +59,18 @@ h1 {
 }
 
 h2 {
-  font-size: 1.5em;
+  font-size: var(--font-size-h2);
   margin-top: 2.5rem;
   margin-bottom: 1.25rem;
 }
 
 h3 {
-  font-size: 1.3em;
+  font-size: var(--font-size-h3);
   margin-top: 2rem;
 }
 
 h4 {
-  font-size: 1.1em;
-}
-
-@media (--phone) {
-  h1 {
-    font-size: 1.6em;
-  }
-
-  h2 {
-    font-size: 1.4em;
-  }
-
-  h3 {
-    font-size: 1.2em;
-  }
-
-  h4 {
-    font-size: 1.1em;
-  }
+  font-size: var(--font-size-h4);
 }
 
 a {
@@ -171,7 +158,7 @@ figure {
 code, kbd {
   font-family: 'JetBrains Mono', 'Fira Code', Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
   background: var(--code-bg);
-  color: #7c3aed;
+  color: var(--code-color);
   padding: 2px 8px;
   margin: 0 2px;
   border-radius: 6px;
@@ -193,7 +180,7 @@ p code,
 li code,
 td code {
   background: var(--code-bg);
-  color: #7c3aed;
+  color: var(--code-color);
 }
 
 /* Override PaperMod's post-single.css (.post-content code { font-size: 0.78em }) */


### PR DESCRIPTION
## Why

- Refresh the blog styling based on current (2026) web design trends: fluid typography, optimized reading experience, and modern CSS features.
- N/A (no related issue)

## What

- Convert fixed `font-size` values for body and h1–h4 to fluid `clamp()` scales, removing the abrupt phone breakpoint jumps.
- Add `text-wrap: balance` to headings and `text-wrap: pretty` to paragraphs for better line breaks (notably effective for mixed JP/EN text).
- Move the hardcoded inline-code color (`#7c3aed`) into a `--code-color` CSS variable that adapts to dark mode (lighter Tokyo Night purple).
- Tune body `line-height` from 1.9 to 1.8 for tighter, more readable JP body text.
- Note: background colors and the light/dark palette are unchanged.

## Reference

- [Optimal Line Length for Readability (UXPin)](https://www.uxpin.com/studio/blog/optimal-line-length-for-readability/)
- [Fluid Typescale with Modern CSS](https://clampgenerator.com/blog/fluid-typescale-modern-css-without-media-queries/)